### PR TITLE
Avoid crashing on a dlist term with no description

### DIFF
--- a/packages/antora-xref-extension/lib/index.js
+++ b/packages/antora-xref-extension/lib/index.js
@@ -7,6 +7,7 @@ function register ({ config }) {
   const stubs = config?.stub && config.stub.map((stub) => new RegExp(stub))
   let disableProcessing
   let componentVersionAsciiDocConfigs
+  let docLogger
 
   this.once('contextStarted', () => {
     const { resolveAsciiDocConfig: resolveAsciiDocConfigDelegate, loadAsciiDoc } = this.getFunctions()
@@ -39,6 +40,7 @@ function register ({ config }) {
   function process (loadAsciiDoc, context, siteAsciiDocConfig, doc) {
     if (disableProcessing) return
     const { file, contentCatalog } = context
+    docLogger = doc.getLogger()
     const lookup = (resourceId) => {
       const resource = resourceId !== '' ? contentCatalog.resolveResource(resourceId, file.src) : file
       if (!resource || (resource.mediaType !== 'text/asciidoc' && !resource.src.contents)) {
@@ -96,8 +98,10 @@ function register ({ config }) {
 
   function processNode (src, node, lookup) {
     try {
-      if (!node.getContext && Array.isArray(node)) {
-        node.forEach((element) => processNode(src, element, lookup))
+      if (!node?.getContext) {
+        // a node without a context is either a group of nodes (such as the terms of a dlist item) or, in the case of a
+        // dlist term with no description, the Opal nil that Asciidoctor uses in place of the missing description
+        if (Array.isArray(node)) node.forEach((element) => processNode(src, element, lookup))
         return
       }
       const context = node.getContext()
@@ -153,6 +157,9 @@ function register ({ config }) {
   }
 
   function log (node, severity, message) {
+    // a node that cannot log against itself is reported against the document instead; logging must never throw here,
+    // since this is the path that reports the original failure
+    if (!node?.getLogger) return docLogger[severity](message)
     node.getLogger()[severity](node.createLogMessage(message, { source_location: node.getSourceLocation() }))
   }
 }

--- a/packages/antora-xref-extension/test/xref-fragments-extension-test.js
+++ b/packages/antora-xref-extension/test/xref-fragments-extension-test.js
@@ -782,6 +782,67 @@ describe('xref extension', () => {
       ).to.be.true()
     })
 
+    it('should allow dlist term with no description', () => {
+      addFile(
+        'target.adoc',
+        heredoc`
+      = Target
+
+      [[frag]]
+      == Fragment
+      The Fragment
+      `
+      )
+      addFile(
+        'xref.adoc',
+        heredoc`
+      = Dlist
+
+      Go read xref:target.adoc#frag[Existing]
+
+      Term::
+      `
+      )
+      run()
+      const page = contentCatalog.getPages((candidate) => candidate.path === '/xref.adoc')[0]
+      expect(page.contents.toString()).to.include('<a href="target.adoc#frag" class="xref page">Existing</a>')
+      expect(loggerDestination.messages).to.be.empty()
+    })
+
+    it('should allow dlist term whose description is a sibling block', () => {
+      addFile(
+        'target.adoc',
+        heredoc`
+      = Target
+
+      [[frag]]
+      == Fragment
+      The Fragment
+      `
+      )
+      addFile(
+        'xref.adoc',
+        heredoc`
+      = Dlist
+
+      [tabs]
+      ====
+      Java::
+      [source,java]
+      ----
+      int x = 1;
+      ----
+      ====
+
+      Go read xref:target.adoc#frag[Existing]
+      `
+      )
+      run()
+      const page = contentCatalog.getPages((candidate) => candidate.path === '/xref.adoc')[0]
+      expect(page.contents.toString()).to.include('<a href="target.adoc#frag" class="xref page">Existing</a>')
+      expect(loggerDestination.messages).to.be.empty()
+    })
+
     function addFile (filename, contents) {
       contents = Buffer.from(contents)
       const mediaType = 'text/asciidoc'


### PR DESCRIPTION
## Problem

A description list term with no description crashes the xref tree walk:

```adoc
Term::
```

The build reports:

```
Parse error when validating xrefs (node.getLogger is not a function)
```

That message names neither the real error nor a location. With `runtime.log.failure_level: warn`, it fails the build outright.

The shape that hits this in practice is a `[tabs]` block missing the `+` list continuation, so the source block becomes a sibling of the dlist instead of the term's description:

```adoc
[tabs]
====
Java::
[source,java]
----
int x = 1;
----
====
```

Found while integrating the extension into the Apache Camel website build, against `1.0.0-alpha.5`.

## Root cause

Two defects, the second masking the first.

**1. `processNode` dereferences the missing description.** gh-4 / #5 added a guard for the array nodes of a dlist item, and that commit message already quoted the Asciidoctor docs: *"If a description is not set, then the second entry in the tuple is nil."* That nil case was never handled. Opal's `nil` is a truthy JS object with neither `getContext` nor `getBlocks`, so `Array.isArray(node)` is false, the guard falls through, and `node.getContext()` throws.

**2. `log` throws while reporting the failure.** It assumes every node has `getLogger`, `createLogMessage`, and `getSourceLocation`. When the node that caused the original exception is exactly the kind that lacks them, the handler throws a *second* exception, which propagates to the parent frame's `catch`, which calls `log` on the `[terms, description]` array, which throws a *third* time. Only at the grandparent dlist node does a log call finally succeed, by which point the original error is gone. Recovering it took patching `console.error(ex.stack)` into the catch locally.

## Fix

- Widen the guard so anything without a context is skipped rather than dereferenced, instead of only handling arrays.
- Fall back to the document logger when the failing node cannot log against itself, so the error handler can never itself throw.

## Testing

Two new tests, both of which fail on `main` with the misleading `node.getLogger is not a function` warning:

- `should allow dlist term with no description` — the minimal `Term::` reproducer
- `should allow dlist term whose description is a sibling block` — the real-world `[tabs]` shape

Each asserts that an xref elsewhere in the document still resolves *and* that nothing is logged, so they fail if the walk aborts or emits a spurious warning.

`npm test` (30 passing), `npm run lint`, `npm run coverage-strict`, and `npm run format` are all clean on Node 20.

## Notes for reviewers

- **The `log` fallback branch is not covered by a test.** Once the guard is fixed, no document shape I could find reaches it through the public API; injecting a broken node would need group-registration machinery unlike anything else in the test suite. I left it in anyway because it is what turned a one-minute diagnosis into a multi-build investigation. Happy to drop it if you would rather not carry untested defensive code.
- I did not add an `== Unreleased` entry to `CHANGELOG.adoc`, since previous fixes did not. Glad to add one if you want it.
- The `Parse error when validating xrefs (...)` wording is still inaccurate for non-parse failures, and `ex.stack` is still dropped. Both felt out of scope here; say the word and I will include them.
